### PR TITLE
TASK-7

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -27,12 +27,20 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
     console.log("uploadFile to", url);
     if (!file) return;
 
+    const authorization_token = localStorage.getItem("authorization_token");
+    if (!authorization_token) {
+      return alert("Please specify your authorization token");
+    }
+
     // Get the presigned URL
     const response = await axios({
       method: "GET",
       url,
       params: {
         name: encodeURIComponent(file.name),
+      },
+      headers: {
+        Authorization: `Basic ${authorization_token}`,
       },
     });
     console.log("File to upload: ", file.name);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,25 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { theme } from "~/theme";
+import axios from "axios";
+
+axios.interceptors.response.use(
+  (response) => {
+    console.log("response", JSON.stringify(response));
+    return response;
+  },
+  (error) => {
+    const responseStatus = error.response.status;
+
+    if (responseStatus === 400) {
+      alert(error.response.data?.data);
+    }
+    if (responseStatus === 403 || responseStatus === 401) {
+      alert(error.response.data?.message);
+    }
+    return Promise.reject(error.response);
+  }
+);
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
Finished with TASK-7 for FE part:

You should add authorization_token to your localStorage for the application to test it on your end with a token:
`localStorage.setItem("authorization_token", "TmlraXRvenoxMzpURVNUX1BBU1NXT1JE")`

_!!! Please note that my import file functionality could apparently be broken but you should get at least the SignedUrl link_

Task 7.3

- [x] Request from the client application to the `/import` path of the Import Service should have Basic Authorization header
- [x] Client should get `authorization_token` value from browser [localStorage]

Additional:

- [x] +30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the `nodejs-aws-fe-main/src/index.tsx` file.

Links:

- FE App CloudFront link: https://djli799ppaabs.cloudfront.net/
- BE PR for the task: https://github.com/Nikitozz13/shop-aws-backend/pull/7
- GET /import api: https://2tubbygjn2.execute-api.eu-west-2.amazonaws.com/dev/import
